### PR TITLE
Add support for Eurocom Q6

### DIFF
--- a/module/clevo-xsm-wmi.c
+++ b/module/clevo-xsm-wmi.c
@@ -1573,6 +1573,15 @@ static struct dmi_system_id clevo_xsm_dmi_table[] __initdata = {
 		.callback = clevo_xsm_dmi_matched,
 		.driver_data = &kb_full_color_with_extra_ops,
 	},
+		{
+		.ident = "Eurocom Q6",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Eurocom"),
+			DMI_MATCH(DMI_BOARD_NAME, "Q6"),
+		},
+		.callback = clevo_xsm_dmi_matched,
+		.driver_data = &kb_full_color_ops,
+	},
 	{
 		.ident = "Clevo P65_67RSRP",
 		.matches = {


### PR DESCRIPTION
The Eurocom Q6 is based on the P950ER chassis.
However, this vendor's DMI is populated with a vendor and board name that does not follow Clevo's conventional naming scheme.
For this reason, its' added as a vendor (Eurocom) with a specified board name (Q6).